### PR TITLE
Hotfix/v0.6.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.2
+current_version = 0.6.3
 commit = True
 
 [bumpversion:file:README.md]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/jkawamoto/go-pixeldrain.svg?style=svg)](https://circleci.com/gh/jkawamoto/go-pixeldrain)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jkawamoto/go-pixeldrain.svg)](https://pkg.go.dev/github.com/jkawamoto/go-pixeldrain)
 [![codecov](https://codecov.io/gh/jkawamoto/go-pixeldrain/branch/master/graph/badge.svg?token=ppX3MVIqWA)](https://codecov.io/gh/jkawamoto/go-pixeldrain)
-[![Release](https://img.shields.io/badge/release-0.6.2-brightgreen.svg)](https://github.com/jkawamoto/go-pixeldrain/releases/tag/v0.6.2)
+[![Release](https://img.shields.io/badge/release-0.6.3-brightgreen.svg)](https://github.com/jkawamoto/go-pixeldrain/releases/tag/v0.6.3)
 
 
 ## Usage

--- a/cmd/pd/main.go
+++ b/cmd/pd/main.go
@@ -25,7 +25,7 @@ const (
 	// Name defines the basename of this program.
 	Name = "pd"
 	// Version defines current version number.
-	Version = "0.6.2"
+	Version = "0.6.3"
 )
 
 // commandNotFound shows error message and exit when a given command is not found.


### PR DESCRIPTION
This hotfix fixes that downloaded files will be written in stdout if `--dir` is not given, which is the old behaviour.