### PR TITLE
Update Go install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ brew install pixeldrain
 To build the newest version, use go get command:
 
 ```
-$ go get github.com/jkawamoto/go-pixeldrain
+$ go install github.com/jkawamoto/go-pixeldrain/cmd/pd@latest
 ```
 
 Otherwise, compiled binaries are also available in [GitHub](https://github.com/jkawamoto/go-pixeldrain/releases).


### PR DESCRIPTION
### Summary

This pull request updates the Go installation command in the README file. The command now uses `go install` with versioning instead of `go get`, ensuring compatibility with newer Go versions and providing better clarity to users.

### Changes

- Replaced `go get` with `go install` in the README file.
- Included versioning for more accurate installation instructions.